### PR TITLE
remove crate mod from type aliases for Point2 & Vector2

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -5,9 +5,9 @@ pub enum RectAttr<'a> {
 }
 
 /// A 2 dimensional point representing a location
-pub(crate) type Point2 = cgmath::Point2<f32>;
+pub type Point2 = cgmath::Point2<f32>;
 /// A 2 dimensional vector representing an offset of a location
-pub(crate) type Vector2 = cgmath::Vector2<f32>;
+pub type Vector2 = cgmath::Vector2<f32>;
 
 /// A simple 2D rectangle.
 ///


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/not-fl3/megaui/2)
<!-- Reviewable:end -->
