### PR TITLE
text_editor: specify EditboxState::cursor and EditboxState::selection in bytes instead of mix of bytes and code points

### DIFF
--- a/src/widgets/editbox/text_editor.rs
+++ b/src/widgets/editbox/text_editor.rs
@@ -187,14 +187,12 @@ impl EditboxState {
         }
     }
     pub fn find_line_begin(&self, text: &str) -> u32 {
-        let mut line_position = 0;
         let mut cursor_tmp = self.cursor.min(text.len().max(1) as u32 - 1 );
 
         while cursor_tmp > 0 && text.as_bytes()[cursor_tmp as usize] != b'\n' {
             cursor_tmp -= 1;
-            line_position += 1;
         }
-        line_position
+        self.cursor - cursor_tmp
     }
 
     pub fn find_line_end(&self, text: &str) -> u32 {


### PR DESCRIPTION
Also removes quadratic complexity by not using chars().nth() in the loop.

Needs someone to look over and test in megaui, as I have tested only in my codebase (not megaui), may need fixes for drawing and updating cursor/selection whenever string changes, something like:
```
            while !text.is_char_boundary(state.cursor as usize) {
                state.cursor -= 1;
            }
```
Have not fixed the rest as I am not familiar with megaui code yet.