### PR TITLE
Button can now have its default Layout overriden + cleanup of Cursor::fit

### DIFF
--- a/src/ui/cursor.rs
+++ b/src/ui/cursor.rs
@@ -80,44 +80,54 @@ impl Cursor {
     }
 
     pub fn fit(&mut self, size: Vector2, mut layout: Layout) -> Vector2 {
-        let res;
-
-	if self.next_same_line {
-	    self.next_same_line = false;
-	    layout = Layout::Horizontal;
-	}
+        let result;
+    
+        if self.next_same_line {
+            self.next_same_line = false;
+            layout = Layout::Horizontal;
+        }
+        
         match layout {
             Layout::Horizontal => {
-		self.max_row_y = self.max_row_y.max(size.y);
-
-                if self.x + size.x < self.area.w as f32 - self.margin * 2. {
-                    res = Vector2::new(self.x, self.y);
+                self.max_row_y = self.max_row_y.max(size.y);
+    
+                // does the requested size fit into the remaining horizontal area
+                if self.x + size.x < self.area.w - self.margin * 2. {
+                    result = Vector2::new(self.x, self.y);
                 } else {
+                    // If not, then set self.x to the beginning (left),
+                    // and self.y to the 'next line' (down)
                     self.x = self.margin;
                     self.y += self.max_row_y + self.margin;
-		    self.max_row_y = 0.;
-                    res = Vector2::new(self.x, self.y);
+                    self.max_row_y = 0.;
+                    result = Vector2::new(self.x, self.y);
                 }
+    
                 self.x += size.x + self.margin;
             }
             Layout::Vertical => {
-		if self.x != self.margin {
-		    self.x = self.margin;
-		    self.y += self.max_row_y;
-		}
-                res = Vector2::new(self.x, self.y);
-		self.x += size.x + self.margin;
+                // if the cursor is not already on the beginning of the line,
+                // jump to the 'next line' (down, and left)
+                if self.x != self.margin {
+                    self.x = self.margin;
+                    self.y += self.max_row_y;
+                }
+                result = Vector2::new(self.x, self.y);
+                self.x += size.x + self.margin;
                 self.max_row_y = size.y + self.margin;
             }
             Layout::Free(point) => {
-                res = point;
+                result = point;
             }
         }
+    
         self.scroll.inner_rect = self
             .scroll
             .inner_rect
-            .combine_with(Rect::new(res.x, res.y, size.x, size.y));
-        res + Vector2::new(self.area.x as f32, self.area.y as f32)
+            .combine_with(Rect::new(result.x, result.y, size.x, size.y));
+    
+        result
+            + Vector2::new(self.area.x, self.area.y)
             + self.scroll.scroll
             + Vector2::new(self.ident, 0.)
     }

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -6,6 +6,7 @@ pub struct Button<'a> {
     position: Option<Vector2>,
     size: Option<Vector2>,
     label: Cow<'a, str>,
+    layout: Layout,
 }
 
 impl<'a> Button<'a> {
@@ -17,6 +18,7 @@ impl<'a> Button<'a> {
             position: None,
             size: None,
             label: label.into(),
+            layout: Layout::Vertical,
         }
     }
 
@@ -33,6 +35,10 @@ impl<'a> Button<'a> {
         }
     }
 
+    pub fn layout(self, layout: Layout) -> Self {
+        Self { layout, ..self }
+    }
+
     pub fn ui(self, ui: &mut Ui) -> bool {
         let context = ui.get_active_window_context();
 
@@ -47,7 +53,7 @@ impl<'a> Button<'a> {
         let pos = context
             .window
             .cursor
-            .fit(size, self.position.map_or(Layout::Vertical, Layout::Free));
+            .fit(size, self.position.map_or(self.layout, Layout::Free));
         let rect = Rect::new(pos.x, pos.y, size.x as f32, size.y as f32);
         let hovered = rect.contains(context.input.mouse_position);
 


### PR DESCRIPTION
Just like with Group, now Button can optionally have it's default overridden.
Also you have the cleanup commit because I don't know how to separate commits from PRs :)

The only thing I am not sure about is that i changed the variable 'res' to 'result' because at the time that had more meaning to me. and I was thinking maybe res = resource.

But I have since seen an example of res to mean result in the Rust Book, so maybe res is idiomatic.