### PR TITLE
Switch to glam

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,6 @@ Simple, zero-depdenencies, immediate mode UI library
 
 [dependencies]
 miniquad_text_rusttype = { version = "0.1", default-features = false }
+glam = "0.9.5"
 #miniquad_text_rusttype = { path = "../miniquad_text_rusttype", version = "0.1", default-features = true }
 

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -3,17 +3,17 @@
 use crate::ui::WindowContext;
 use crate::Color;
 use crate::Rect;
-use crate::Vector2;
+use glam::Vec2;
 
 pub struct DrawCanvas<'a> {
     pub(crate) context: WindowContext<'a>,
 }
 
 impl<'a> DrawCanvas<'a> {
-    pub fn cursor(&self) -> Vector2 {
+    pub fn cursor(&self) -> Vec2 {
         let cursor = &self.context.window.cursor;
-        Vector2::new(cursor.x, cursor.y)
-            + Vector2::new(cursor.area.x as f32, cursor.area.y as f32)
+        cursor.pos()
+            + cursor.area.area()
             + cursor.scroll.scroll
     }
 

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -13,7 +13,7 @@ impl<'a> DrawCanvas<'a> {
     pub fn cursor(&self) -> Vec2 {
         let cursor = &self.context.window.cursor;
         cursor.pos()
-            + cursor.area.area()
+            + cursor.area.size()
             + cursor.scroll.scroll
     }
 

--- a/src/draw_command.rs
+++ b/src/draw_command.rs
@@ -1,4 +1,6 @@
-use crate::{Color, Rect, Vector2};
+use crate::{Color, Rect};
+
+use glam::Vec2;
 
 use miniquad_text_rusttype::FontAtlas;
 
@@ -20,14 +22,14 @@ pub(crate) enum DrawCommand {
         fill: Option<Color>,
     },
     DrawTriangle {
-        p0: Vector2,
-        p1: Vector2,
-        p2: Vector2,
+        p0: Vec2,
+        p1: Vec2,
+        p2: Vec2,
         color: Color,
     },
     DrawLine {
-        start: Vector2,
-        end: Vector2,
+        start: Vec2,
+        end: Vec2,
         color: Color,
     },
     DrawRawTexture {
@@ -40,7 +42,7 @@ pub(crate) enum DrawCommand {
 }
 
 impl DrawCommand {
-    pub fn offset(&self, offset: Vector2) -> DrawCommand {
+    pub fn offset(&self, offset: Vec2) -> DrawCommand {
         match self.clone() {
             DrawCommand::DrawCharacter {
                 dest,
@@ -119,7 +121,7 @@ impl CommandsList {
         0.
     }
 
-    pub fn label_size(&self, label: &str, multiline: Option<f32>) -> Vector2 {
+    pub fn label_size(&self, label: &str, multiline: Option<f32>) -> Vec2 {
         let width = label.split('\n').fold(0.0f32, |max_width, line| {
             max_width.max(line.chars().map(|c| self.character_advance(c)).sum::<f32>())
         });
@@ -127,14 +129,14 @@ impl CommandsList {
             line_height * label.split('\n').count() as f32
         });
 
-        Vector2::new(width, height)
+        Vec2::new(width, height)
     }
 
     /// If character is in font atlas - will return x advance from position to potential next character position
     pub fn draw_character(
         &mut self,
         character: char,
-        position: Vector2,
+        position: Vec2,
         color: Color,
     ) -> Option<f32> {
         if let Some(font_data) = self.font_atlas.character_infos.get(&character) {
@@ -150,16 +152,12 @@ impl CommandsList {
 
             let cmd = DrawCommand::DrawCharacter {
                 dest: Rect::new(
-                    left_coord + position.x,
-                    top_coord + position.y,
-                    font_data.size.0,
-                    font_data.size.1,
+                    position + Vec2::new(left_coord, top_coord),
+                    Vec2::from(font_data.size),
                 ),
                 source: Rect::new(
-                    font_data.tex_coords.0,
-                    font_data.tex_coords.1,
-                    font_data.tex_size.0,
-                    font_data.tex_size.1,
+                    Vec2::from(font_data.tex_coords),
+                    Vec2::from(font_data.tex_size),
                 ),
                 color: color,
             };
@@ -172,9 +170,9 @@ impl CommandsList {
         }
     }
 
-    pub fn draw_label<T: Into<LabelParams>>(&mut self, label: &str, position: Vector2, params: T) {
+    pub fn draw_label<T: Into<LabelParams>>(&mut self, label: &str, position: Vec2, params: T) {
         if self.clipping_zone.map_or(false, |clip| {
-            !clip.overlaps(&Rect::new(position.x - 150., position.y - 25., 200., 50.))
+            !clip.overlaps(&Rect::new(position - Vec2::new(150.0, 25.0), Vec2::new(200., 50.)))
         }) {
             return;
         }
@@ -185,7 +183,7 @@ impl CommandsList {
         for character in label.chars() {
             if let Some(advance) = self.draw_character(
                 character,
-                position + Vector2::new(total_width, 0.),
+                position + Vec2::new(total_width, 0.),
                 params.color,
             ) {
                 total_width += advance;
@@ -225,7 +223,7 @@ impl CommandsList {
         })
     }
 
-    pub fn draw_triangle<T>(&mut self, p0: Vector2, p1: Vector2, p2: Vector2, color: T)
+    pub fn draw_triangle<T>(&mut self, p0: Vec2, p1: Vec2, p2: Vec2, color: T)
     where
         T: Into<Color>,
     {
@@ -243,7 +241,7 @@ impl CommandsList {
         })
     }
 
-    pub fn draw_line<T: Into<Color>>(&mut self, start: Vector2, end: Vector2, color: T) {
+    pub fn draw_line<T: Into<Color>>(&mut self, start: Vec2, end: Vec2, color: T) {
         if self
             .clipping_zone
             .map_or(false, |clip| !clip.contains(start) && !clip.contains(end))

--- a/src/draw_command.rs
+++ b/src/draw_command.rs
@@ -172,7 +172,7 @@ impl CommandsList {
 
     pub fn draw_label<T: Into<LabelParams>>(&mut self, label: &str, position: Vec2, params: T) {
         if self.clipping_zone.map_or(false, |clip| {
-            !clip.overlaps(&Rect::new(position - Vec2::new(150.0, 25.0), Vec2::new(200., 50.)))
+            !clip.overlaps(&Rect::parts(position.x() - 150.0, position.y() - 25.0, 200., 50.))
         }) {
             return;
         }

--- a/src/draw_list.rs
+++ b/src/draw_list.rs
@@ -1,6 +1,6 @@
 use crate::draw_command::DrawCommand;
 use crate::types::{Color, Rect};
-use crate::Vector2;
+use glam::Vec2;
 
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
@@ -59,7 +59,7 @@ impl DrawList {
     pub fn draw_rectangle_lines(&mut self, rect: Rect, color: Color) {
         let Rect { x, y, w, h } = rect;
 
-        self.draw_rectangle(Rect { x, y, w, h: 1. }, Rect::new(0., 0., 0., 0.), color);
+        self.draw_rectangle(Rect { x, y, w, h: 1. }, Rect::zero(), color);
         self.draw_rectangle(
             Rect {
                 x: x + w - 1.,
@@ -67,7 +67,7 @@ impl DrawList {
                 w: 1.,
                 h: h - 2.,
             },
-            Rect::new(0., 0., 0., 0.),
+            Rect::zero(),
             color,
         );
         self.draw_rectangle(
@@ -77,7 +77,7 @@ impl DrawList {
                 w,
                 h: 1.,
             },
-            Rect::new(0., 0., 0., 0.),
+            Rect::zero(),
             color,
         );
         self.draw_rectangle(
@@ -87,7 +87,7 @@ impl DrawList {
                 w: 1.,
                 h: h - 2.,
             },
-            Rect::new(0., 0., 0., 0.),
+            Rect::zero(),
             color,
         );
     }
@@ -110,11 +110,11 @@ impl DrawList {
             .extend(indices.iter().map(|i| i + indices_offset));
     }
 
-    fn draw_triangle(&mut self, p0: Vector2, p1: Vector2, p2: Vector2, color: Color) {
+    fn draw_triangle(&mut self, p0: Vec2, p1: Vec2, p2: Vec2, color: Color) {
         let vertices = [
-            Vertex::new(p0.x, p0.y, 0.0, 0.0, color),
-            Vertex::new(p1.x, p1.y, 0.0, 0.0, color),
-            Vertex::new(p2.x, p2.y, 0.0, 0.0, color),
+            Vertex::new(p0.x(), p0.y(), 0.0, 0.0, color),
+            Vertex::new(p1.x(), p1.y(), 0.0, 0.0, color),
+            Vertex::new(p2.x(), p2.y(), 0.0, 0.0, color),
         ];
         let indices: [u16; 3] = [0, 1, 2];
 
@@ -196,14 +196,14 @@ pub(crate) fn render_command(draw_lists: &mut Vec<DrawList>, command: DrawComman
         }
         DrawCommand::DrawRect { rect, fill, stroke } => {
             if let Some(fill) = fill {
-                active_draw_list.draw_rectangle(rect, Rect::new(0., 0., 0., 0.), fill);
+                active_draw_list.draw_rectangle(rect, Rect::zero(), fill);
             }
             if let Some(stroke) = stroke {
                 active_draw_list.draw_rectangle_lines(rect, stroke);
             }
         }
         DrawCommand::DrawLine { start, end, color } => {
-            active_draw_list.draw_line(start.x, start.y, end.x, end.y, 1., color);
+            active_draw_list.draw_line(start.x(), start.y(), end.x(), end.y(), 1., color);
         }
         DrawCommand::DrawCharacter {
             dest,
@@ -215,7 +215,7 @@ pub(crate) fn render_command(draw_lists: &mut Vec<DrawList>, command: DrawComman
         DrawCommand::DrawRawTexture { rect, .. } => {
             active_draw_list.draw_rectangle(
                 rect,
-                Rect::new(0., 0., 1., 1.),
+                Rect::one(),
                 Color::new(1., 1., 1., 1.),
             );
         }

--- a/src/input_handler.rs
+++ b/src/input_handler.rs
@@ -1,3 +1,5 @@
+use glam::Vec2;
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum KeyCode {
     Up,
@@ -19,10 +21,10 @@ pub enum KeyCode {
 }
 
 pub trait InputHandler {
-    fn mouse_down(&mut self, position: (f32, f32));
-    fn mouse_up(&mut self, _: (f32, f32));
+    fn mouse_down(&mut self, position: Vec2);
+    fn mouse_up(&mut self, _: Vec2);
     fn mouse_wheel(&mut self, x: f32, y: f32);
-    fn mouse_move(&mut self, position: (f32, f32));
+    fn mouse_move(&mut self, position: Vec2);
     fn char_event(&mut self, character: char, shift: bool, ctrl: bool);
     fn key_down(&mut self, key_down: KeyCode, shift: bool, ctrl: bool);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub mod widgets;
 pub use draw_list::{DrawList, Vertex};
 pub use input_handler::{InputHandler, KeyCode};
 pub use style::Style;
-pub use types::{Color, Rect, Vector2};
+pub use types::{Color, Rect};
 pub use ui::{Drag, Layout, Ui};
 
 pub type Id = u64;

--- a/src/types.rs
+++ b/src/types.rs
@@ -85,8 +85,8 @@ impl Rect {
         Vec2::new(self.x, self.y)
     }
 
-    /// Returns the top-left corner of the `Rect`
-    pub fn area(&self) -> Vec2 {
+    /// Returns a Vec2 containing the width and height of the Rect.
+    pub fn size(&self) -> Vec2 {
         Vec2::new(self.w, self.h)
     }
 
@@ -134,7 +134,7 @@ impl Rect {
     }
 
     pub fn offset(self, offset: Vec2) -> Rect {
-        Rect::new(self.top_left() + offset, self.area())
+        Rect::new(self.top_left() + offset, self.size())
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,40 +1,4 @@
-#[derive(Copy, Clone, Default, Debug)]
-pub struct Vector2 {
-    pub x: f32,
-    pub y: f32,
-}
-
-impl Vector2 {
-    pub fn new(x: f32, y: f32) -> Vector2 {
-        Vector2 { x, y }
-    }
-
-    pub fn distance(self, other: Vector2) -> f32 {
-        ((self.x - other.x) * (self.x - other.x) + (self.y - other.y) * (self.y - other.y)).sqrt()
-    }
-}
-
-impl std::ops::Add for Vector2 {
-    type Output = Vector2;
-
-    fn add(self, rhs: Vector2) -> Vector2 {
-        Vector2 {
-            x: self.x + rhs.x,
-            y: self.y + rhs.y,
-        }
-    }
-}
-
-impl std::ops::Sub for Vector2 {
-    type Output = Vector2;
-
-    fn sub(self, rhs: Vector2) -> Vector2 {
-        Vector2 {
-            x: self.x - rhs.x,
-            y: self.y - rhs.y,
-        }
-    }
-}
+use glam::Vec2;
 
 /// A simple 2D rectangle.
 ///
@@ -54,7 +18,14 @@ pub struct Rect {
 
 impl Rect {
     /// Create a new `Rect`.
-    pub fn new(x: f32, y: f32, w: f32, h: f32) -> Self {
+    pub fn new(pos: Vec2, size: Vec2) -> Self {
+        let (x, y) = pos.into();
+        let (w, h) = size.into();
+        Rect { x, y, w, h }
+    }
+
+    /// Create a new `Rect` directly from scalar components
+    pub fn parts(x: f32, y: f32, w: f32, h: f32) -> Self {
         Rect { x, y, w, h }
     }
 
@@ -81,12 +52,12 @@ impl Rect {
 
     /// Create a new `Rect` with all values zero.
     pub fn zero() -> Self {
-        Self::new(0.0, 0.0, 0.0, 0.0)
+        Self::new(Vec2::zero(), Vec2::zero())
     }
 
     /// Creates a new `Rect` at `0,0` with width and height 1.
     pub fn one() -> Self {
-        Self::new(0.0, 0.0, 1.0, 1.0)
+        Self::new(Vec2::zero(), Vec2::one())
     }
 
     /// Returns the left edge of the `Rect`
@@ -109,12 +80,22 @@ impl Rect {
         self.y + self.h
     }
 
+    /// Returns the top-left corner of the `Rect`
+    pub fn top_left(&self) -> Vec2 {
+        Vec2::new(self.x, self.y)
+    }
+
+    /// Returns the top-left corner of the `Rect`
+    pub fn area(&self) -> Vec2 {
+        Vec2::new(self.w, self.h)
+    }
+
     /// Checks whether the `Rect` contains a `Point`
-    pub fn contains(&self, point: Vector2) -> bool {
-        point.x >= self.left()
-            && point.x <= self.right()
-            && point.y <= self.bottom()
-            && point.y >= self.top()
+    pub fn contains(&self, point: Vec2) -> bool {
+        point.x() >= self.left()
+            && point.x() <= self.right()
+            && point.y() <= self.bottom()
+            && point.y() >= self.top()
     }
 
     /// Checks whether the `Rect` overlaps another `Rect`
@@ -152,8 +133,8 @@ impl Rect {
         })
     }
 
-    pub fn offset(self, offset: Vector2) -> Rect {
-        Rect::new(self.x + offset.x, self.y + offset.y, self.w, self.h)
+    pub fn offset(self, offset: Vec2) -> Rect {
+        Rect::new(self.top_left() + offset, self.area())
     }
 }
 

--- a/src/ui/cursor.rs
+++ b/src/ui/cursor.rs
@@ -48,8 +48,8 @@ pub struct Cursor {
 }
 
 impl Cursor {
-    pub fn new(rect: Rect, margin: f32) -> Cursor {
-        let area = rect.area();
+    pub fn new(area: Rect, margin: f32) -> Cursor {
+        let size = area.size();
         Cursor {
             margin,
             x: margin,
@@ -58,15 +58,15 @@ impl Cursor {
             start_x: margin,
             start_y: margin,
             scroll: Scroll {
-                rect: Rect::new(Vec2::zero(), area),
-                inner_rect: Rect::new(Vec2::zero(), area),
-                inner_rect_previous_frame: Rect::new(Vec2::zero(), area),
+                rect: Rect::new(Vec2::zero(), size),
+                inner_rect: Rect::new(Vec2::zero(), size),
+                inner_rect_previous_frame: Rect::new(Vec2::zero(), size),
                 scroll: Vec2::zero(),
                 dragging_x: false,
                 dragging_y: false,
                 initial_scroll: Vec2::zero(),
             },
-            area: rect,
+            area,
 	    next_same_line: None,
 	    max_row_y: 0.
         }
@@ -82,7 +82,7 @@ impl Cursor {
 	self.max_row_y = 0.;
         self.ident = 0.;
         self.scroll.inner_rect_previous_frame = self.scroll.inner_rect;
-        self.scroll.inner_rect = Rect::new(Vec2::zero(), self.area.area());
+        self.scroll.inner_rect = Rect::new(Vec2::zero(), self.area.size());
     }
 
     pub fn fit(&mut self, size: Vec2, mut layout: Layout) -> Vec2 {
@@ -126,7 +126,7 @@ impl Cursor {
             .scroll
             .inner_rect
             .combine_with(Rect::new(res, size));
-        res + self.area.area()
+        res + self.area.size()
             + self.scroll.scroll
             + Vec2::new(self.ident, 0.)
     }

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -1,4 +1,4 @@
-use crate::types::Vector2;
+use glam::Vec2;
 
 pub use crate::input_handler::KeyCode;
 
@@ -17,11 +17,11 @@ pub struct InputCharacter {
 
 #[derive(Default, Clone)]
 pub struct Input {
-    pub(crate) mouse_position: Vector2,
+    pub(crate) mouse_position: Vec2,
     pub(crate) is_mouse_down: bool,
     pub(crate) click_down: bool,
     pub(crate) click_up: bool,
-    pub(crate) mouse_wheel: Vector2,
+    pub(crate) mouse_wheel: Vec2,
     pub(crate) input_buffer: Vec<InputCharacter>,
     pub(crate) cursor_grabbed: bool,
     // TODO: its a hack to prevent button click behind modal
@@ -45,7 +45,7 @@ impl Input {
         self.click_down = false;
         self.click_up = false;
         self.modal_active = false;
-        self.mouse_wheel = Vector2::new(0., 0.);
+        self.mouse_wheel = Vec2::zero();
         self.input_buffer = vec![];
     }
 }

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -1,10 +1,11 @@
-use crate::{types::Vector2, Layout, Rect, Ui};
+use crate::{Layout, Rect, Ui};
+use glam::Vec2;
 
 use std::borrow::Cow;
 
 pub struct Button<'a> {
-    position: Option<Vector2>,
-    size: Option<Vector2>,
+    position: Option<Vec2>,
+    size: Option<Vec2>,
     label: Cow<'a, str>,
 }
 
@@ -20,13 +21,13 @@ impl<'a> Button<'a> {
         }
     }
 
-    pub fn position<P: Into<Option<Vector2>>>(self, position: P) -> Self {
+    pub fn position<P: Into<Option<Vec2>>>(self, position: P) -> Self {
         let position = position.into();
 
         Button { position, ..self }
     }
 
-    pub fn size(self, size: Vector2) -> Self {
+    pub fn size(self, size: Vec2) -> Self {
         Button {
             size: Some(size),
             ..self
@@ -38,17 +39,14 @@ impl<'a> Button<'a> {
 
         let size = self.size.unwrap_or_else(|| {
             context.window.draw_commands.label_size(&self.label, None)
-                + Vector2::new(
-                    context.global_style.margin_button * 2.,
-                    context.global_style.margin_button,
-                )
+                + Vec2::new(2.0, 1.0) * context.global_style.margin_button
         });
 
         let pos = context
             .window
             .cursor
             .fit(size, self.position.map_or(Layout::Vertical, Layout::Free));
-        let rect = Rect::new(pos.x, pos.y, size.x as f32, size.y as f32);
+        let rect = Rect::new(pos, size);
         let hovered = rect.contains(context.input.mouse_position);
 
         context.window.draw_commands.draw_rect(
@@ -62,10 +60,7 @@ impl<'a> Button<'a> {
         );
         context.window.draw_commands.draw_label(
             &self.label,
-            pos + Vector2::new(
-                context.global_style.margin_button,
-                context.global_style.margin_button,
-            ),
+            pos + Vec2::one() * context.global_style.margin_button,
             Some(context.global_style.text(context.focused)),
         );
 
@@ -74,7 +69,7 @@ impl<'a> Button<'a> {
 }
 
 impl Ui {
-    pub fn button<P: Into<Option<Vector2>>>(&mut self, position: P, label: &str) -> bool {
+    pub fn button<P: Into<Option<Vec2>>>(&mut self, position: P, label: &str) -> bool {
         Button::new(label).position(position).ui(self)
     }
 }

--- a/src/widgets/combobox.rs
+++ b/src/widgets/combobox.rs
@@ -1,9 +1,10 @@
 use crate::Color;
 use crate::{
+    types::Rect,
     hash,
-    types::{Rect, Vector2},
     Id, Layout, Ui,
 };
+use glam::Vec2;
 
 pub struct ComboBox<'a, 'b, 'c> {
     id: Id,
@@ -31,7 +32,7 @@ impl<'a, 'b, 'c> ComboBox<'a, 'b, 'c> {
     pub fn ui(self, ui: &mut Ui) -> usize {
         let context = ui.get_active_window_context();
 
-        let size = Vector2::new(
+        let size = Vec2::new(
             context.window.cursor.area.w
                 - context.global_style.margin * 2.
                 - context.window.cursor.ident,
@@ -39,10 +40,10 @@ impl<'a, 'b, 'c> ComboBox<'a, 'b, 'c> {
         );
         let pos = context.window.cursor.fit(size, Layout::Vertical);
 
-        let active_area_w = size.x / 2.;
+        let active_area_w = size.x() / 2.;
         let triangle_area_w = 19.;
 
-        let clickable_rect = Rect::new(pos.x, pos.y, active_area_w, size.y);
+        let clickable_rect = Rect::new(pos, Vec2::new(active_area_w, size.y()));
         let hovered = clickable_rect.contains(context.input.mouse_position);
 
         let (ref mut state, ref mut selection) = context
@@ -60,30 +61,28 @@ impl<'a, 'b, 'c> ComboBox<'a, 'b, 'c> {
         );
         context.window.draw_commands.draw_label(
             self.variants[*selection],
-            Vector2::new(pos.x + 5., pos.y + 2.),
+            pos + Vec2::new(5.0, 2.0),
             Color::from_rgba(0, 0, 0, 255),
         );
 
         context.window.draw_commands.draw_rect(
             Rect::new(
-                pos.x + active_area_w - triangle_area_w,
-                pos.y,
-                triangle_area_w,
-                size.y,
+                pos + Vec2::new(active_area_w - triangle_area_w, 0.0),
+                Vec2::new(triangle_area_w, size.y()),
             ),
             context.global_style.editbox_background(context.focused),
             None,
         );
         context.window.draw_commands.draw_triangle(
-            Vector2::new(pos.x + active_area_w - triangle_area_w + 4.0, pos.y + 4.0),
-            Vector2::new(pos.x + active_area_w - 4.0, pos.y + 4.0),
-            Vector2::new(pos.x + active_area_w - triangle_area_w / 2.0, pos.y + 15.0),
+            pos + Vec2::new(active_area_w - triangle_area_w + 4.0, 4.0),
+            pos + Vec2::new(active_area_w - 4.0, 4.0),
+            pos + Vec2::new(active_area_w - triangle_area_w / 2.0, 15.0),
             Color::new(0.7, 0.7, 0.7, 1.0),
         );
 
         context.window.draw_commands.draw_label(
             self.label,
-            Vector2::new(pos.x + size.x / 2. + 5., pos.y + 2.),
+            pos + Vec2::new(size.x() / 2.0 + 5.0, 2.0),
             Color::from_rgba(0, 0, 0, 255),
         );
 
@@ -95,7 +94,7 @@ impl<'a, 'b, 'c> ComboBox<'a, 'b, 'c> {
             let context = ui.begin_modal(
                 hash!("combobox", self.id),
                 pos,
-                Vector2::new(200.0, self.variants.len() as f32 * 20.0 + 20.0),
+                Vec2::new(200.0, self.variants.len() as f32 * 20.0 + 20.0),
             );
 
             let (ref mut state, ref mut selection) = context
@@ -104,10 +103,8 @@ impl<'a, 'b, 'c> ComboBox<'a, 'b, 'c> {
 
             for (i, variant) in self.variants.iter().enumerate() {
                 let rect = Rect::new(
-                    pos.x + 5.0,
-                    pos.y + i as f32 * 20.0 + 20.0,
-                    active_area_w - 5.0,
-                    20.0,
+                    pos + Vec2::new(5.0, i as f32 * 20.0 + 20.0),
+                    Vec2::new(active_area_w - 5.0, 20.0),
                 );
                 let hovered = rect.contains(context.input.mouse_position);
 
@@ -123,7 +120,7 @@ impl<'a, 'b, 'c> ComboBox<'a, 'b, 'c> {
 
                 context.window.draw_commands.draw_label(
                     variant,
-                    Vector2::new(pos.x + 7., pos.y + i as f32 * 20.0 + 20.0 + 2.0),
+                    pos + Vec2::new(7.0, i as f32 * 20.0 + 20.0 + 2.0),
                     Color::from_rgba(0, 0, 0, 255),
                 );
 

--- a/src/widgets/editbox.rs
+++ b/src/widgets/editbox.rs
@@ -1,16 +1,17 @@
 use crate::{
     hash,
-    types::{Rect, Vector2},
+    types::Rect,
     ui::{InputCharacter, Key, KeyCode},
     Id, Layout, Ui,
 };
+use glam::Vec2;
 
 pub struct Editbox<'a> {
     id: Id,
-    size: Vector2,
+    size: Vec2,
     multiline: bool,
     filter: Option<&'a dyn Fn(char) -> bool>,
-    pos: Option<Vector2>,
+    pos: Option<Vec2>,
     line_height: f32,
 }
 
@@ -22,7 +23,7 @@ const LEFT_MARGIN: f32 = 2.;
 const N_SPACES_IN_TAB: usize = 4;
 
 impl<'a> Editbox<'a> {
-    pub fn new(id: Id, size: Vector2) -> Editbox<'a> {
+    pub fn new(id: Id, size: Vec2) -> Editbox<'a> {
         Editbox {
             id,
             size,
@@ -37,7 +38,7 @@ impl<'a> Editbox<'a> {
         Editbox { multiline, ..self }
     }
 
-    pub fn position(self, pos: Vector2) -> Self {
+    pub fn position(self, pos: Vec2) -> Self {
         Editbox {
             pos: Some(pos),
             ..self
@@ -271,7 +272,7 @@ impl<'a> Editbox<'a> {
             .pos
             .unwrap_or_else(|| context.window.cursor.fit(self.size, Layout::Vertical));
 
-        let rect = Rect::new(pos.x, pos.y, self.size.x, self.size.y);
+        let rect = Rect::new(pos, self.size);
 
         let hovered = rect.contains(context.input.mouse_position);
 
@@ -337,12 +338,12 @@ impl<'a> Editbox<'a> {
 
         let mut context = ui.begin_window(self.id, parent_id, pos, self.size, 0., false);
 
-        let size = Vector2::new(150., self.line_height * text.split('\n').count() as f32);
+        let size = Vec2::new(150., self.line_height * text.split('\n').count() as f32);
 
         let pos = context
             .window
             .cursor
-            .fit(size, Layout::Free(Vector2::new(5., 5.)));
+            .fit(size, Layout::Free(Vec2::new(5., 5.)));
 
         context.window.draw_commands.clip(parent_rect);
 
@@ -365,7 +366,7 @@ impl<'a> Editbox<'a> {
             let character = text.chars().nth(n).unwrap_or(' ');
             if n == state.cursor as usize {
                 context.window.draw_commands.draw_rect(
-                    Rect::new(pos.x + x, pos.y + y - 2., 2., 13.),
+                    Rect::new(pos + Vec2::new(x, y - 2.), Vec2::new(2., 13.)),
                     context
                         .global_style
                         .editbox_cursor(context.focused, input_focused),
@@ -377,14 +378,14 @@ impl<'a> Editbox<'a> {
                 advance = context
                     .window
                     .draw_commands
-                    .draw_character(character, pos + Vector2::new(x, y), color)
+                    .draw_character(character, pos + Vec2::new(x, y), color)
                     .unwrap_or(0.);
             }
             if state.in_selected_range(n as u32) {
-                let pos = pos + Vector2::new(x, y);
+                let pos = pos + Vec2::new(x, y);
 
                 context.window.draw_commands.draw_rect(
-                    Rect::new(pos.x, pos.y - 2., advance, 13.),
+                    Rect::new(pos - Vec2::new(0.0, 2.0), Vec2::new(advance, 13.0)),
                     None,
                     context.global_style.selection_background(context.focused),
                 );
@@ -392,16 +393,16 @@ impl<'a> Editbox<'a> {
 
             if clicked == false && hovered && context.input.is_mouse_down() && input_focused {
                 let cursor_on_current_line =
-                    (context.input.mouse_position.y - (pos.y + y + self.line_height / 2.)).abs()
+                    (context.input.mouse_position.y() - (pos.y() + y + self.line_height / 2.)).abs()
                         < self.line_height / 2. + 0.1;
                 let line_end = character == '\n' || n == text.len();
-                let cursor_after_line_end = context.input.mouse_position.x > (pos.x + x);
+                let cursor_after_line_end = context.input.mouse_position.x() > (pos.x() + x);
                 let clickable_character = character != '\n';
                 let cursor_on_character =
-                    (context.input.mouse_position.x - (pos.x + x)).abs() < advance / 2.;
+                    (context.input.mouse_position.x() - (pos.x() + x)).abs() < advance / 2.;
                 let last_character = n == text.len();
                 let cursor_below_line =
-                    (context.input.mouse_position.y - (pos.y + y + self.line_height)) > 0.;
+                    (context.input.mouse_position.y() - (pos.y() + y + self.line_height)) > 0.;
 
                 if (cursor_on_current_line && line_end && cursor_after_line_end)
                     || (cursor_on_current_line && clickable_character && cursor_on_character)
@@ -439,7 +440,7 @@ impl<'a> Editbox<'a> {
 }
 
 impl Ui {
-    pub fn editbox(&mut self, id: Id, size: Vector2, text: &mut String) -> bool {
+    pub fn editbox(&mut self, id: Id, size: Vec2, text: &mut String) -> bool {
         Editbox::new(id, size).ui(self, text)
     }
 }

--- a/src/widgets/group.rs
+++ b/src/widgets/group.rs
@@ -1,22 +1,23 @@
 use crate::{
-    types::{Rect, Vector2},
+    types::Rect,
     ui::{Drag, DragState},
     Id, Layout, Ui,
 };
+use glam::Vec2;
 
 #[derive(Debug, Clone)]
 pub struct Group {
     id: Id,
-    position: Option<Vector2>,
+    position: Option<Vec2>,
     layout: Layout,
-    size: Vector2,
+    size: Vec2,
     draggable: bool,
     highlight: bool,
     hoverable: bool,
 }
 
 impl Group {
-    pub fn new(id: Id, size: Vector2) -> Group {
+    pub fn new(id: Id, size: Vec2) -> Group {
         Group {
             id,
             size,
@@ -28,7 +29,7 @@ impl Group {
         }
     }
 
-    pub fn position(self, position: Vector2) -> Group {
+    pub fn position(self, position: Vec2) -> Group {
         Group {
             position: Some(position),
             ..self
@@ -70,7 +71,7 @@ impl Group {
             self.size,
             self.position.map_or(self.layout, Layout::Free),
         );
-        let rect = Rect::new(pos.x, pos.y, self.size.x, self.size.y);
+        let rect = Rect::new(pos, self.size);
         let parent_id = Some(parent.window.id);
 
         let mut context = ui.begin_window(self.id, parent_id, pos, self.size, 0., true);
@@ -85,7 +86,7 @@ impl Group {
         if let Some((id, DragState::Clicked(orig))) = context.dragging {
             if *id == self.id
                 && context.input.is_mouse_down
-                && context.input.mouse_position.distance(*orig) > 5.
+                && (context.input.mouse_position - *orig).length() > 5.
             {
                 *context.dragging = Some((self.id, DragState::Dragging(*orig)));
             }
@@ -138,8 +139,8 @@ impl Group {
 pub struct GroupToken {
     draggable: bool,
     drag: Drag,
-    pos: Vector2,
-    size: Vector2,
+    pos: Vec2,
+    size: Vec2,
 }
 
 impl GroupToken {
@@ -152,12 +153,11 @@ impl GroupToken {
             if
                 //parent.dragging.is_none()
                 context.input.is_mouse_down
-                    && Rect::new(self.pos.x, self.pos.y, self.size.x, self.size.y)
-                    .contains(context.input.mouse_position)
+                    && Rect::new(self.pos, self.size).contains(context.input.mouse_position)
             {
                 // *context.dragging = Some((
                 //     id,
-                //     DragState::Clicked(context.input.mouse_position, Vector2::new(rect.x, rect.y)),
+                //     DragState::Clicked(context.input.mouse_position, Vec2::new(rect.x, rect.y)),
                 // ));
             }
         }
@@ -169,7 +169,7 @@ impl GroupToken {
 }
 
 impl Ui {
-    pub fn group<F: FnOnce(&mut Ui)>(&mut self, id: Id, size: Vector2, f: F) -> Drag {
+    pub fn group<F: FnOnce(&mut Ui)>(&mut self, id: Id, size: Vec2, f: F) -> Drag {
         Group::new(id, size).ui(self, f)
     }
 }

--- a/src/widgets/input_field.rs
+++ b/src/widgets/input_field.rs
@@ -1,13 +1,14 @@
 use crate::{
-    types::{Color, Vector2},
+    types::Color,
     widgets::Editbox,
     Id, Layout, Ui,
 };
+use glam::Vec2;
 
 pub struct InputField<'a> {
     id: Id,
     label: &'a str,
-    size: Option<Vector2>,
+    size: Option<Vec2>,
     numbers: bool,
 }
 
@@ -30,7 +31,7 @@ impl<'a> InputField<'a> {
         }
     }
 
-    pub fn size(self, size: Vector2) -> Self {
+    pub fn size(self, size: Vec2) -> Self {
         Self {
             size: Some(size),
             ..self
@@ -48,7 +49,7 @@ impl<'a> InputField<'a> {
         let context = ui.get_active_window_context();
 
         let size = self.size.unwrap_or_else(|| {
-            Vector2::new(
+            Vec2::new(
                 context.window.cursor.area.w
                     - context.global_style.margin * 2.
                     - context.window.cursor.ident,
@@ -58,11 +59,11 @@ impl<'a> InputField<'a> {
         let pos = context.window.cursor.fit(size, Layout::Vertical);
 
         let editbox_area_w = if self.label.is_empty() {
-            size.x
+            size.x()
         } else {
-            size.x / 2.
+            size.x() / 2.
         };
-        let mut editbox = Editbox::new(self.id, Vector2::new(editbox_area_w, size.y))
+        let mut editbox = Editbox::new(self.id, Vec2::new(editbox_area_w, size.y()))
             .position(pos)
             .multiline(false);
         if self.numbers {
@@ -76,7 +77,7 @@ impl<'a> InputField<'a> {
         if self.label.is_empty() == false {
             context.window.draw_commands.draw_label(
                 self.label,
-                Vector2::new(pos.x + size.x / 2. + 5., pos.y + 2.),
+                pos + Vec2::new(size.x() / 2. + 5., 2.),
                 Color::from_rgba(0, 0, 0, 255),
             );
         }

--- a/src/widgets/label.rs
+++ b/src/widgets/label.rs
@@ -1,9 +1,10 @@
-use crate::{types::Vector2, Layout, Ui};
+use crate::{Layout, Ui};
+use glam::Vec2;
 
 use std::borrow::Cow;
 
 pub struct Label<'a> {
-    position: Option<Vector2>,
+    position: Option<Vec2>,
     multiline: Option<f32>,
     label: Cow<'a, str>,
 }
@@ -27,7 +28,7 @@ impl<'a> Label<'a> {
         }
     }
 
-    pub fn position<P: Into<Option<Vector2>>>(self, position: P) -> Self {
+    pub fn position<P: Into<Option<Vec2>>>(self, position: P) -> Self {
         let position = position.into();
 
         Label { position, ..self }
@@ -41,20 +42,20 @@ impl<'a> Label<'a> {
             .draw_commands
             .label_size(&self.label, self.multiline);
 
-        size.y += context.global_style.margin * 2.;
+        *size.y_mut() += context.global_style.margin * 2.;
 
         let color = context.global_style.text(context.focused);
         let pos = context
             .window
             .cursor
             .fit(size, self.position.map_or(Layout::Vertical, Layout::Free))
-            + Vector2::new(0., context.global_style.margin);
+            + Vec2::new(0., context.global_style.margin);
 
         if let Some(line_height) = self.multiline {
             for (n, line) in self.label.split('\n').enumerate() {
                 context.window.draw_commands.draw_label(
                     line,
-                    pos + Vector2::new(0., n as f32 * line_height),
+                    pos + Vec2::new(0., n as f32 * line_height),
                     color,
                 )
             }
@@ -68,7 +69,7 @@ impl<'a> Label<'a> {
 }
 
 impl Ui {
-    pub fn label<P: Into<Option<Vector2>>>(&mut self, position: P, label: &str) {
+    pub fn label<P: Into<Option<Vec2>>>(&mut self, position: P, label: &str) {
         Label::new(label).position(position).ui(self)
     }
 }

--- a/src/widgets/separator.rs
+++ b/src/widgets/separator.rs
@@ -1,10 +1,11 @@
-use crate::{types::Vector2, Layout, Ui};
+use crate::{Layout, Ui};
+use glam::Vec2;
 
 impl Ui {
     pub fn separator(&mut self) {
         let context = self.get_active_window_context();
 
-        let size = Vector2::new(
+        let size = Vec2::new(
             context.window.cursor.area.w
                 - context.global_style.margin * 2.
                 - context.window.cursor.ident,
@@ -14,8 +15,8 @@ impl Ui {
         let pos = context.window.cursor.fit(size, Layout::Vertical);
 
         context.window.draw_commands.draw_line(
-            Vector2::new(pos.x, pos.y + 2.),
-            Vector2::new(pos.x + size.x, pos.y + 2.),
+            pos + Vec2::new(0.0, 2.0),
+            pos + Vec2::new(size.x(), 2.0),
             context.global_style.separator(context.focused),
         );
     }

--- a/src/widgets/slider.rs
+++ b/src/widgets/slider.rs
@@ -1,9 +1,10 @@
 use crate::{
     hash,
-    types::{Rect, Vector2},
+    types::Rect,
     widgets::Editbox,
     Id, Layout, Ui,
 };
+use glam::Vec2;
 use std::ops::Range;
 
 pub struct Slider<'a> {
@@ -32,7 +33,7 @@ impl<'a> Slider<'a> {
     pub fn ui(self, ui: &mut Ui, data: &mut f32) {
         let context = ui.get_active_window_context();
 
-        let size = Vector2::new(
+        let size = Vec2::new(
             context.window.cursor.area.w
                 - context.global_style.margin * 3.
                 - context.window.cursor.ident,
@@ -42,7 +43,7 @@ impl<'a> Slider<'a> {
 
         let editbox_width = 50.;
         let label_width = 100.;
-        let slider_width = size.x - editbox_width - label_width;
+        let slider_width = size.x() - editbox_width - label_width;
         let margin = 5.;
 
         let mut temp_string = context
@@ -58,7 +59,7 @@ impl<'a> Slider<'a> {
             let _ = write!(&mut temp_string, "{:.2}", *data);
         }
 
-        Editbox::new(editbox_id, Vector2::new(50., size.y))
+        Editbox::new(editbox_id, Vec2::new(50., size.y()))
             .position(pos)
             .multiline(false)
             .filter(&|character| character.is_digit(10) || character == '.' || character == '-')
@@ -83,12 +84,12 @@ impl<'a> Slider<'a> {
             .entry(hash!(self.id, "dragging"))
             .or_insert(0);
 
-        let slider_start_x = editbox_width + pos.x + margin;
+        let slider_start_x = editbox_width + pos.x() + margin;
         let data_pos = (*data - self.range.start) / (self.range.end - self.range.start)
             * slider_width
             + slider_start_x;
 
-        let bar_rect = Rect::new(data_pos - 4., pos.y, 8., 20.);
+        let bar_rect = Rect::parts(data_pos - 4., pos.y(), 8., 20.);
         let hovered = bar_rect.contains(context.input.mouse_position);
 
         if hovered && context.input.is_mouse_down() {
@@ -104,7 +105,7 @@ impl<'a> Slider<'a> {
         }
 
         if *dragging == 1 {
-            let mouse_position = ((context.input.mouse_position.x - slider_start_x) / slider_width)
+            let mouse_position = ((context.input.mouse_position.x() - slider_start_x) / slider_width)
                 .min(1.)
                 .max(0.);
             let old_data = *data;
@@ -119,11 +120,8 @@ impl<'a> Slider<'a> {
         }
 
         context.window.draw_commands.draw_line(
-            Vector2::new(pos.x + editbox_width + margin, pos.y + size.y / 2.),
-            Vector2::new(
-                pos.x + editbox_width + slider_width + margin,
-                pos.y + size.y / 2.,
-            ),
+            pos + Vec2::new(editbox_width + margin, size.y() / 2.0),
+            pos + Vec2::new(editbox_width + slider_width + margin, size.y() / 2.0),
             context.global_style.text(context.focused),
         );
 
@@ -135,10 +133,7 @@ impl<'a> Slider<'a> {
 
         context.window.draw_commands.draw_label(
             self.label,
-            Vector2::new(
-                pos.x + editbox_width + slider_width + margin * 2.,
-                pos.y + 2.,
-            ),
+            pos + Vec2::new(editbox_width + slider_width + margin * 2.0, 2.0),
             context.global_style.text(context.focused),
         );
 

--- a/src/widgets/tabbar.rs
+++ b/src/widgets/tabbar.rs
@@ -1,18 +1,19 @@
 use crate::{
     draw_command::Aligment,
-    types::{Color, Rect, Vector2},
+    types::{Color, Rect},
     Id, Layout, Ui,
 };
+use glam::Vec2;
 
 pub struct Tabbar {
     id: Id,
-    position: Vector2,
-    size: Vector2,
+    position: Vec2,
+    size: Vec2,
     tabs: &'static [&'static str],
 }
 
 impl Tabbar {
-    pub fn new(id: Id, position: Vector2, size: Vector2, tabs: &'static [&'static str]) -> Tabbar {
+    pub fn new(id: Id, position: Vec2, size: Vec2, tabs: &'static [&'static str]) -> Tabbar {
         Tabbar {
             id,
             position,
@@ -29,15 +30,13 @@ impl Tabbar {
             .cursor
             .fit(self.size, Layout::Free(self.position));
 
-        let width = self.size.x as f32 / self.tabs.len() as f32;
+        let width = self.size.x() / self.tabs.len() as f32;
         let selected = *context.storage_u32.entry(self.id).or_insert(0);
 
         for (n, label) in self.tabs.iter().enumerate() {
             let rect = Rect::new(
-                pos.x + width * n as f32 + 1.,
-                pos.y,
-                width - 2.,
-                self.size.y,
+                pos + Vec2::new(width * n as f32 + 1.0, 0.0),
+                Vec2::new(width - 2.0, self.size.y()),
             );
             let hovered = rect.contains(context.input.mouse_position);
             let selected = n as u32 == selected;
@@ -58,7 +57,7 @@ impl Tabbar {
 
             context.window.draw_commands.draw_label(
                 label,
-                pos + Vector2::new(
+                pos + Vec2::new(
                     width * n as f32 + width / 2.,
                     context.global_style.margin_button + 2.,
                 ),
@@ -80,8 +79,8 @@ impl Ui {
     pub fn tabbar(
         &mut self,
         id: Id,
-        position: Vector2,
-        size: Vector2,
+        position: Vec2,
+        size: Vec2,
         tabs: &'static [&'static str],
     ) -> u32 {
         Tabbar::new(id, position, size, tabs).ui(self)

--- a/src/widgets/texture.rs
+++ b/src/widgets/texture.rs
@@ -1,7 +1,8 @@
-use crate::{types::Vector2, Layout, Rect, Ui};
+use crate::{Layout, Rect, Ui};
+use glam::Vec2;
 
 pub struct Texture {
-    position: Option<Vector2>,
+    position: Option<Vec2>,
     w: f32,
     h: f32,
     texture: u32,
@@ -21,7 +22,7 @@ impl Texture {
         Texture { w, h, ..self }
     }
 
-    pub fn position<P: Into<Option<Vector2>>>(self, position: P) -> Self {
+    pub fn position<P: Into<Option<Vec2>>>(self, position: P) -> Self {
         let position = position.into();
 
         Texture { position, ..self }
@@ -30,7 +31,7 @@ impl Texture {
     pub fn ui(self, ui: &mut Ui) -> bool {
         let context = ui.get_active_window_context();
 
-        let size = Vector2::new(self.w, self.h);
+        let size = Vec2::new(self.w, self.h);
 
         let pos = context
             .window
@@ -39,10 +40,9 @@ impl Texture {
         context
             .window
             .draw_commands
-            .draw_raw_texture(Rect::new(pos.x, pos.y, self.w, self.h), self.texture);
+            .draw_raw_texture(Rect::new(pos, Vec2::new(self.w, self.h)), self.texture);
 
-        let rect = Rect::new(pos.x, pos.y, size.x as f32, size.y as f32);
-        let hovered = rect.contains(context.input.mouse_position);
+        let hovered = Rect::new(pos, size).contains(context.input.mouse_position);
 
         context.focused && hovered && context.input.click_up
     }

--- a/src/widgets/tree_node.rs
+++ b/src/widgets/tree_node.rs
@@ -1,7 +1,8 @@
 use crate::{
-    types::{Rect, Vector2},
+    types::Rect,
     Id, Layout, Ui,
 };
+use glam::Vec2;
 
 use std::borrow::Cow;
 
@@ -40,13 +41,12 @@ impl<'a> TreeNode<'a> {
     pub fn begin(self, ui: &mut Ui) -> Option<TreeNodeToken> {
         let context = ui.get_active_window_context();
 
-        let size = Vector2::new(300., 14.);
+        let size = Vec2::new(300., 14.);
 
         let color = context.global_style.text(context.focused);
         let pos = context.window.cursor.fit(size, Layout::Vertical);
 
-        let rect = Rect::new(pos.x, pos.y, size.x as f32, size.y as f32);
-        let hovered = rect.contains(context.input.mouse_position);
+        let hovered = Rect::new(pos, size).contains(context.input.mouse_position);
 
         let clicked = context.focused && hovered && context.input.click_down();
 
@@ -66,7 +66,7 @@ impl<'a> TreeNode<'a> {
         context
             .window
             .draw_commands
-            .draw_label(&*self.label, pos + Vector2::new(10., 0.), color);
+            .draw_label(&*self.label, pos + Vec2::new(10., 0.), color);
 
         if *opened == 1 {
             context.window.cursor.ident += 5.;

--- a/src/widgets/window.rs
+++ b/src/widgets/window.rs
@@ -1,14 +1,15 @@
 use crate::{
-    types::{Rect, Vector2},
+    types::Rect,
     ui::WindowContext,
     Id, Ui,
 };
+use glam::Vec2;
 
 #[derive(Debug, Clone)]
 pub struct Window {
     id: Id,
-    position: Vector2,
-    size: Vector2,
+    position: Vec2,
+    size: Vec2,
     close_button: bool,
     enabled: bool,
     movable: bool,
@@ -17,7 +18,7 @@ pub struct Window {
 }
 
 impl Window {
-    pub fn new(id: Id, position: Vector2, size: Vector2) -> Window {
+    pub fn new(id: Id, position: Vec2, size: Vec2) -> Window {
         Window {
             id,
             position,
@@ -101,17 +102,12 @@ impl Window {
 
     fn draw_close_button(&self, context: &mut WindowContext) -> bool {
         let button_rect = Rect::new(
-            context.window.position.x + context.window.size.x - 15.,
-            context.window.position.y,
-            20.,
-            20.,
+            context.window.position + Vec2::new(context.window.size.x() - 15.0, 0.0),
+            Vec2::one() * 20.0
         );
         context.window.draw_commands.draw_label(
             "X",
-            Vector2::new(
-                context.window.position.x + context.window.size.x - 10.,
-                context.window.position.y + 3.,
-            ),
+            context.window.position + Vec2::new(context.window.size.x() - 10., 3.0),
             Some(context.global_style.title(context.focused)),
         );
         context.focused
@@ -126,7 +122,7 @@ impl Window {
         let size = context.window.size;
 
         context.window.draw_commands.draw_rect(
-            Rect::new(position.x, position.y, size.x, size.y),
+            Rect::new(position, size),
             style.window_border(focused),
             style.background(focused),
         );
@@ -135,13 +131,13 @@ impl Window {
             if let Some(label) = &self.label {
                 context.window.draw_commands.draw_label(
                     &label,
-                    Vector2::new(position.x + style.margin, position.y + style.margin),
+                    position + Vec2::one() * style.margin,
                     context.global_style.title(focused),
                 );
             }
             context.window.draw_commands.draw_line(
-                Vector2::new(position.x, position.y + style.title_height),
-                Vector2::new(position.x + size.x, position.y + style.title_height),
+                position + Vec2::new(0.0, style.title_height),
+                position + Vec2::new(size.x(), style.title_height),
                 style.window_border(focused),
             );
         }
@@ -168,8 +164,8 @@ impl Ui {
     pub fn window<F: FnOnce(&mut Ui)>(
         &mut self,
         id: Id,
-        position: Vector2,
-        size: Vector2,
+        position: Vec2,
+        size: Vec2,
         f: F,
     ) -> bool {
         Window::new(id, position, size).ui(self, f)


### PR DESCRIPTION
Macroquad's README boasts that macroquad avoids complicated Rust concepts, making it easier for beginners to grapple with.
However, there's hardly anything that would confuse a beginner more than trying to figure out where to use `vec2(x, y)` or `megaui::Vector2::new(x, y)`. Even ignoring the cognitive overhead of figuring out when to convert between the two, they would also have to learn two Vector math APIs. I suggest we switch to glam, so that we can use the same Vector Math library throughout the macroquad ecosystem, making things easier for beginners and intermediate users alike.