### PR TITLE
Allow customizing font atlas

### DIFF
--- a/src/draw_command.rs
+++ b/src/draw_command.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use crate::{Color, Rect, Vector2};
 
 use miniquad_text_rusttype::FontAtlas;
@@ -84,11 +85,11 @@ impl DrawCommand {
 pub(crate) struct CommandsList {
     pub commands: Vec<DrawCommand>,
     pub clipping_zone: Option<Rect>,
-    font_atlas: Rc<FontAtlas>,
+    font_atlas: Rc<RefCell<FontAtlas>>,
 }
 
 impl CommandsList {
-    pub fn new(font_atlas: Rc<FontAtlas>) -> CommandsList {
+    pub fn new(font_atlas: Rc<RefCell<FontAtlas>>) -> CommandsList {
         CommandsList {
             commands: vec![],
             clipping_zone: None,
@@ -109,8 +110,8 @@ impl CommandsList {
     /// usually used as an advance between current cursor position
     /// and next potential character
     pub fn character_advance(&self, character: char) -> f32 {
-        if let Some(font_data) = self.font_atlas.character_infos.get(&character) {
-            let font_data = font_data.scale(self.font_atlas.font_size as f32);
+        if let Some(font_data) = self.font_atlas.borrow().character_infos.get(&character) {
+            let font_data = font_data.scale(self.font_atlas.borrow().font_size as f32);
             let advance = font_data.left_padding + font_data.size.0 + font_data.right_padding;
 
             return advance;
@@ -137,8 +138,9 @@ impl CommandsList {
         position: Vector2,
         color: Color,
     ) -> Option<f32> {
-        if let Some(font_data) = self.font_atlas.character_infos.get(&character) {
-            let font_data = font_data.scale(self.font_atlas.font_size as f32);
+        let mut out = None;
+        if let Some(font_data) = self.font_atlas.borrow().character_infos.get(&character) {
+            let font_data = font_data.scale(self.font_atlas.borrow().font_size as f32);
 
             let left_coord = font_data.left_padding;
             // 4.0 cames from lack of understanding of how ttf works
@@ -146,7 +148,7 @@ impl CommandsList {
             // (x, y).....................(x + advance, y)
             // ...........................
             // (x, y + self.font_size.y)..(x + advance, y + _)
-            let top_coord = self.font_atlas.font_size as f32 - font_data.height_over_line - 4.0;
+            let top_coord = self.font_atlas.borrow().font_size as f32 - font_data.height_over_line - 4.0;
 
             let cmd = DrawCommand::DrawCharacter {
                 dest: Rect::new(
@@ -163,12 +165,14 @@ impl CommandsList {
                 ),
                 color: color,
             };
-            self.add_command(cmd);
-
             let advance = font_data.left_padding + font_data.size.0 + font_data.right_padding;
+            out = Some((cmd, advance))
+        }
+        if let Some((cmd, advance)) = out {
+            self.add_command(cmd);
             Some(advance)
         } else {
-            None
+            None    
         }
     }
 

--- a/src/draw_command.rs
+++ b/src/draw_command.rs
@@ -172,7 +172,7 @@ impl CommandsList {
             self.add_command(cmd);
             Some(advance)
         } else {
-            None    
+            None
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub use input_handler::{InputHandler, KeyCode};
 pub use style::Style;
 pub use types::{Color, Rect, Vector2};
 pub use ui::{Drag, Layout, Ui};
+pub use miniquad_text_rusttype::FontAtlas;
 
 pub type Id = u64;
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -550,7 +550,7 @@ impl Ui {
     }
 
     /// Scrolls the middle of the active GUI window to its GUI cursor
-    /// 
+    ///
     /// Note that this does not work on the first frame of the GUI application.
     /// If you want your widget to start with its scrollbar in a particular location,
     /// consider `if ui.frame == 1 { ui.scroll_here() }`.
@@ -559,10 +559,10 @@ impl Ui {
     }
 
     /// Scrolls the active GUI window to its GUI cursor.
-    /// 
+    ///
     /// 1.0 puts the bottom of the window at the GUI cursor,
     /// 0.0 puts the top of the window there.
-    /// 
+    ///
     /// 0.5 as the ratio puts the middle of the window at the GUI cursor,
     /// and is equivalent to `Ui::scroll_here`.
     pub fn scroll_here_ratio(&mut self, ratio: f32) {
@@ -572,7 +572,7 @@ impl Ui {
     }
 
     /// How far the active gui window has been scrolled down on the y axis.
-    /// 
+    ///
     /// Note that for these purposes, a Group widget is still considered a Window
     /// because it can have its own scrollbar.
     pub fn scroll(&mut self) -> Vector2 {
@@ -580,7 +580,7 @@ impl Ui {
     }
 
     /// The farthest down a scrollbar may go given the constraints of its window.
-    /// 
+    ///
     /// Note that for these purposes, a Group widget is still considered a Window
     /// because it can have its own scrollbar.
     pub fn scroll_max(&mut self) -> Vector2 {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -380,7 +380,7 @@ impl Ui {
     pub fn new() -> Ui {
         let mut font_atlas = FontAtlas::new(
             &include_bytes!("../assets/ProggyClean.ttf")[..],
-            13,
+            20,
             FontAtlas::ascii_character_list(),
         )
         .unwrap();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -381,7 +381,7 @@ impl Ui {
     pub fn new() -> Ui {
         let mut font_atlas = FontAtlas::new(
             &include_bytes!("../assets/ProggyClean.ttf")[..],
-            20,
+            13,
             FontAtlas::ascii_character_list(),
         )
         .unwrap();


### PR DESCRIPTION
This allows customizing the font atlas by wrapping it in a `RefCell<T>`. This turned out to be necessary since it gets passed around to Window and draw_command:CommandsList, so merely changing the font_atlas in Ui won't get picked up by existing windows.

I wasn't quite sure what the white_square processing on the font atlas texture was for, but I assumed it should be run any time someone swaps in a new font atlas, which I set up in the `set_font_atlas` function (meant to mirror `set_style`).

There may be better ways to do this, I'm open to suggestions. One thought I had originally was putting font_atlas into the global `Style`, which I couldn't get working but I could probably figure it out if that makes more sense.

It seems to work okay on the UI showcase (just bumped font size to 20 instead of 13):

![resize_font](https://user-images.githubusercontent.com/605546/98466418-68658d80-219d-11eb-8f57-80f51d10a897.gif)

Obviously changing the font size also requires repositioning things and editing Style, which I didn't do in this example.