### PR TITLE
last_item_hovered, last_item_clicked

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -556,6 +556,29 @@ impl Ui {
         }
     }
 
+    /// Returns true if the last widget which had `.ui` called on it is being clicked.
+    pub fn last_item_clicked(&mut self) -> bool {
+        let click_down = self.input.click_down();
+        let mouse_pos = self.input.mouse_position;
+
+        let context = self.get_active_window_context();
+        let last_child = context.window.childs.last().copied();
+        last_child
+            .map(|id| self.windows[&id].cursor.area.contains(mouse_pos) && click_down)
+            .unwrap_or(false)
+    }
+
+    /// Returns true if the mouse is over the last widget which had `.ui` called on it.
+    pub fn last_item_hovered(&mut self) -> bool {
+        let mouse_pos = self.input.mouse_position;
+
+        let context = self.get_active_window_context();
+        let last_child = context.window.childs.last().copied();
+        last_child
+            .map(|id| self.windows[&id].cursor.area.contains(mouse_pos))
+            .unwrap_or(false)
+    }
+
     /// Scrolls the middle of the active GUI window to its GUI cursor
     /// 
     /// Note that this does not work on the first frame of the GUI application.


### PR DESCRIPTION
Fedor noted in the Discord that it may be desirable in the future to have a `last_item_hovered` field on `Context` which is updated by custom hovering logic on a per-widget basis, unfortunately I do not have time to add and especially test this behavior for every widget, so that will have to wait for now.