### PR TITLE
ui: add draft of interface scaling

### DIFF
--- a/src/draw_command.rs
+++ b/src/draw_command.rs
@@ -1,3 +1,5 @@
+use crate::FONT_SCALE;
+use crate::SCALE;
 use crate::{Color, Rect, Vector2};
 
 use miniquad_text_rusttype::FontAtlas;
@@ -118,7 +120,7 @@ impl CommandsList {
             let font_data = font_data.scale(self.font_atlas.font_size as f32);
             let advance = font_data.left_padding + font_data.size.0 + font_data.right_padding;
 
-            return advance;
+            return advance / FONT_SCALE;
         }
 
         0.
@@ -145,42 +147,43 @@ impl CommandsList {
         if let Some(font_data) = self.font_atlas.character_infos.get(&character) {
             let font_data = font_data.scale(self.font_atlas.font_size as f32);
 
-            let left_coord = font_data.left_padding;
+            let left_coord = font_data.left_padding / FONT_SCALE;
             // 4.0 cames from lack of understanding of how ttf works
             // with 4.0 top_coord is a top_coord of any buttons, wich makes a character be drawen like:
             // (x, y).....................(x + advance, y)
             // ...........................
             // (x, y + self.font_size.y)..(x + advance, y + _)
-            let top_coord = self.font_atlas.font_size as f32 - font_data.height_over_line - 4.0;
+            let top_coord = self.font_atlas.font_size as f32 / FONT_SCALE - font_data.height_over_line / FONT_SCALE - 4.0;
 
             let rect = Rect::new(
                 left_coord + position.x,
                 top_coord + position.y,
-                font_data.size.0,
-                font_data.size.1,
+                font_data.size.0 / SCALE,
+                font_data.size.1 / SCALE,
             );
             if self
                 .clipping_zone
                 .map_or(false, |clip| !clip.overlaps(&rect))
             {
                 let advance = font_data.left_padding + font_data.size.0 + font_data.right_padding;
-                return Some(advance);
+                return Some(advance / FONT_SCALE);
             }
 
             let cmd = DrawCommand::DrawCharacter {
                 dest: rect,
                 source: Rect::new(
-                    font_data.tex_coords.0,
-                    font_data.tex_coords.1,
-                    font_data.tex_size.0,
-                    font_data.tex_size.1,
+                    // We divide this by scale, because in vertices is will be multiplied again, and we should get same coordinatesu
+                    font_data.tex_coords.0 / SCALE,
+                    font_data.tex_coords.1 / SCALE,
+                    font_data.tex_size.0 / SCALE,
+                    font_data.tex_size.1 / SCALE,
                 ),
                 color: color,
             };
             self.add_command(cmd);
 
             let advance = font_data.left_padding + font_data.size.0 + font_data.right_padding;
-            Some(advance)
+            Some(advance / FONT_SCALE)
         } else {
             None
         }

--- a/src/draw_list.rs
+++ b/src/draw_list.rs
@@ -1,3 +1,4 @@
+use crate::SCALE;
 use crate::draw_command::DrawCommand;
 use crate::types::{Color, Rect};
 use crate::Vector2;
@@ -26,7 +27,11 @@ impl From<Vertex> for VertexInterop {
 }
 
 impl Vertex {
-    pub fn new(x: f32, y: f32, u: f32, v: f32, color: Color) -> Vertex {
+    pub fn new(mut x: f32, mut y: f32, mut u: f32, mut v: f32, color: Color) -> Vertex {
+        x *= SCALE;
+        y *= SCALE;
+        u *= SCALE;
+        v *= SCALE;
         Vertex {
             pos: [x, y, 0.],
             uv: [u, v],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,9 @@ mod style;
 mod types;
 mod ui;
 
+pub const SCALE: f32 = 1.5;
+pub const FONT_SCALE: f32 = ((13. * SCALE) as u32) as f32 / 13.;
+
 pub mod widgets;
 
 pub use clipboard::ClipboardObject;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,3 +1,4 @@
+use crate::SCALE;
 use crate::{
     canvas::DrawCanvas, draw_command::CommandsList, draw_list::DrawList, types::Rect,
     types::Vector2, InputHandler, Style,
@@ -314,7 +315,10 @@ impl<'a> WindowContext<'a> {
 }
 
 impl InputHandler for Ui {
-    fn mouse_down(&mut self, position: (f32, f32)) {
+    fn mouse_down(&mut self, mut position: (f32, f32)) {
+        position.0 /= SCALE;
+        position.1 /= SCALE;
+
         let position = Vector2::new(position.0, position.1);
 
         self.input.is_mouse_down = true;
@@ -365,7 +369,10 @@ impl InputHandler for Ui {
         self.input.mouse_wheel = Vector2::new(x, y);
     }
 
-    fn mouse_move(&mut self, position: (f32, f32)) {
+    fn mouse_move(&mut self, mut position: (f32, f32)) {
+        position.0 /= SCALE;
+        position.1 /= SCALE;
+
         let position = Vector2::new(position.0, position.1);
 
         // assuming that the click was to the root window
@@ -435,7 +442,7 @@ impl Ui {
     pub fn new() -> Ui {
         let mut font_atlas = FontAtlas::new(
             &include_bytes!("../assets/ProggyClean.ttf")[..],
-            13,
+            (13. * SCALE) as u32,
             FontAtlas::ascii_character_list(),
         )
         .unwrap();
@@ -733,7 +740,10 @@ impl Ui {
         self.input.cursor_grabbed
     }
 
-    pub fn is_mouse_over(&self, mouse_position: Vector2) -> bool {
+    pub fn is_mouse_over(&self, mut mouse_position: Vector2) -> bool {
+        mouse_position.x /= SCALE;
+        mouse_position.y /= SCALE;
+
         for window in self.windows_focus_order.iter() {
             let window = &self.windows[window];
             if window.was_active == false {


### PR DESCRIPTION
This is the draft in case if you want sometimes implement this feature.

Also, `megaui-macroquad` should be changed this way:

```diff
diff --git a/src/lib.rs b/src/lib.rs
index 50bb57f..29a8553 100644
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use megaui::SCALE;
 use std::collections::HashMap;
 
 use macroquad::prelude::*;
@@ -237,7 +238,7 @@ pub fn draw_megaui() {
         quad_gl.scissor(
             draw_command
                 .clipping_zone
-                .map(|rect| (rect.x as i32, rect.y as i32, rect.w as i32, rect.h as i32)),
+                .map(|rect| ((rect.x * SCALE) as i32, (rect.y * SCALE) as i32, (rect.w * SCALE) as i32, (rect.h * SCALE) as i32)),
         );
         quad_gl.draw_mode(DrawMode::Triangles);
         quad_gl.geometry(&draw_command.vertices, &draw_command.indices);

```